### PR TITLE
fix: ensure connect event is fired only once

### DIFF
--- a/test/src/PgPubSub.ts
+++ b/test/src/PgPubSub.ts
@@ -93,6 +93,26 @@ describe('PgPubSub', () => {
 
             pubSub.connect().catch(() => { /**/ });
         });
+        it('should fire connect event only once', done => {
+            let connectCalls = 0;
+
+            // emulate termination
+            (pgClient as any).connect = () => {
+                if (connectCalls < 1) {
+                    pgClient.emit('error');
+                }
+
+                else {
+                    pgClient.emit('connect');
+                }
+
+                connectCalls++;
+            };
+
+            // test will fail if done is called more than once
+            pubSub.on('connect', done);
+            pubSub.connect().catch(() => { /**/ });
+        });
         it('should support automatic reconnect on errors', done => {
             let counter = 0;
 


### PR DESCRIPTION
Hey, thanks for the library. I found a bug with the reconnects, and here's a fix.

Basically, when connect() failed and it started reconnecting, it kept adding more and more listeners to pgClient connect event, and when it finally fired, all those listeners would also fire. So if it had to reconnect 5 times before succeeding, the connect event would have been fired 6 times.

Try the test without the fix, it will fail.